### PR TITLE
added support for tweet_mode=extended results

### DIFF
--- a/src/parse.jl
+++ b/src/parse.jl
@@ -14,6 +14,7 @@ function to_TWEETS(object::Dict)
                     get(object, "favorite_count", nothing),                 #    favorite_count
                     get(object, "favorited", nothing),                      #    favorited
                     get(object, "filter_level", nothing),                   #    filter_level
+                    get(object, "full_text", nothing),                           #    full_text
                     get(object, "id", nothing),                             #    id
                     get(object, "id_str", nothing),                         #    id_str
                     get(object, "in_reply_to_screen_name", nothing),        #    in_reply_to_screen_name

--- a/src/types.jl
+++ b/src/types.jl
@@ -79,6 +79,7 @@ type TWEETS
     favorite_count::@compat(Union{Int, Void})
     favorited::@compat(Union{Bool, Void})
     filter_level::@compat(Union{AbstractString, Void})
+    full_text::@compat(Union{AbstractString, Void})
     id::@compat(Union{Int, Void})
     id_str::@compat(Union{AbstractString, Void})
     in_reply_to_screen_name::@compat(Union{AbstractString, Void})


### PR DESCRIPTION
The Twitter REST API allows passing a GET param, `tweet_mode=extended`. 
The library allows such as request, for instance: 
`get_search_tweets("#julialang", options = Dict("tweet_mode" => "extended", "result_type" => "recent"))`

In this situation, an extra field is made available in the response, `full_text`. Added support for that. 